### PR TITLE
Thread local as dynamic so that threads will communicate status

### DIFF
--- a/plunit.pl
+++ b/plunit.pl
@@ -560,7 +560,7 @@ test_set_option(concurrent(V)) :-
                  *        RUNNING TOPLEVEL      *
                  *******************************/
 
-:- thread_local
+:- dynamic
     passed/5,                       % Unit, Test, Line, Det, Time
     failed/4,                       % Unit, Test, Line, Reason
     failed_assertion/7,             % Unit, Test, Line, ALoc, STO, Reason, Goal


### PR DESCRIPTION
The overall run_tests should fail if any test fails, but that requires that we coordinate book-keeping through the various predicates `passed/5`, `failed/4`, `failed_assertion/7` etc.  For now I've just re-declared them as dynamic rather than thread_local.