### PR TITLE
Remove the dot after the URL

### DIFF
--- a/plunit.pl
+++ b/plunit.pl
@@ -50,8 +50,8 @@
 
 /** <module> Unit Testing
 
-Unit testing environment for SWI-Prolog and   SICStus Prolog. For usage,
-please visit http://www.swi-prolog.org/pldoc/package/plunit.
+Unit testing environment for SWI-Prolog and SICStus Prolog. For usage,
+please visit http://www.swi-prolog.org/pldoc/package/plunit
 */
 
 :- autoload(library(apply), [maplist/3,include/3]).


### PR DESCRIPTION
The link on https://eu.swi-prolog.org/pldoc/doc/_SWI_/library/plunit.pl is broken due to the trailing dot being treated as part of the URL.